### PR TITLE
wrap assertion in a setTimeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,18 @@
 export default function (babel) {
   const t = babel.types;
 
+  function timeout (assert) {
+    return t.expressionStatement(
+      t.callExpression(
+        t.identifier('setTimeout'),
+        [
+          t.functionExpression(null, [], t.blockStatement([assert])),
+          t.numericLiteral(0),
+        ]
+      )
+    );
+  }
+
   function console_ (method, args) {
     return t.expressionStatement(t.callExpression(
       t.memberExpression(
@@ -10,7 +22,7 @@ export default function (babel) {
   }
 
   function consoleTest (thing, fromValue) {
-    return console_('assert',
+    const assert = console_('assert',
       [
         t.binaryExpression('!==', t.unaryExpression('typeof', t.identifier(thing)), t.stringLiteral('undefined')),
         t.stringLiteral('[IMPORT]:'),
@@ -20,6 +32,8 @@ export default function (babel) {
         t.stringLiteral('is undefined.'),
       ]
     );
+
+    return timeout(assert);
   }
 
   return {

--- a/test/fixtures/destructuring/expected.js
+++ b/test/fixtures/destructuring/expected.js
@@ -8,7 +8,15 @@ var _derp2 = _interopRequireDefault(_derp);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-console.assert(typeof _bar.baz !== 'undefined', '[IMPORT]:', 'baz', 'from', 'bar', 'is undefined.');
-console.assert(typeof _bar.foo !== 'undefined', '[IMPORT]:', 'foo', 'from', 'bar', 'is undefined.');
-console.assert(typeof _derp.herpette !== 'undefined', '[IMPORT]:', 'herpette', 'from', 'derp', 'is undefined.');
-console.assert(typeof _derp2.default !== 'undefined', '[IMPORT]:', 'herp', 'from', 'derp', 'is undefined.');
+setTimeout(function () {
+  console.assert(typeof _bar.baz !== 'undefined', '[IMPORT]:', 'baz', 'from', 'bar', 'is undefined.');
+}, 0);
+setTimeout(function () {
+  console.assert(typeof _bar.foo !== 'undefined', '[IMPORT]:', 'foo', 'from', 'bar', 'is undefined.');
+}, 0);
+setTimeout(function () {
+  console.assert(typeof _derp.herpette !== 'undefined', '[IMPORT]:', 'herpette', 'from', 'derp', 'is undefined.');
+}, 0);
+setTimeout(function () {
+  console.assert(typeof _derp2.default !== 'undefined', '[IMPORT]:', 'herp', 'from', 'derp', 'is undefined.');
+}, 0);

--- a/test/fixtures/standard/expected.js
+++ b/test/fixtures/standard/expected.js
@@ -10,5 +10,9 @@ var _derp2 = _interopRequireDefault(_derp);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-console.assert(typeof _bar2.default !== 'undefined', '[IMPORT]:', 'foo', 'from', 'bar', 'is undefined.');
-console.assert(typeof _derp2.default !== 'undefined', '[IMPORT]:', 'herp', 'from', 'derp', 'is undefined.');
+setTimeout(function () {
+  console.assert(typeof _bar2.default !== 'undefined', '[IMPORT]:', 'foo', 'from', 'bar', 'is undefined.');
+}, 0);
+setTimeout(function () {
+  console.assert(typeof _derp2.default !== 'undefined', '[IMPORT]:', 'herp', 'from', 'derp', 'is undefined.');
+}, 0);


### PR DESCRIPTION
This is to allow the circular dependencies to fully resolve before asserting.

fixes #2
